### PR TITLE
Show seek controls even when video is paused

### DIFF
--- a/xml/DialogSeekBar.xml
+++ b/xml/DialogSeekBar.xml
@@ -417,7 +417,7 @@
 			</control>
 			<control type="group">
 				<include>VisibleFadeAnimation</include>
-				<visible>!Player.Paused + !Player.Forwarding + !Player.Rewinding + [Player.Seeking | Player.DisplayAfterSeek]</visible>
+				<visible>!Player.Forwarding + !Player.Rewinding + [Player.Seeking | Player.DisplayAfterSeek]</visible>
 				<control type="image">
 					<left>97</left>
 					<bottom>123</bottom>


### PR DESCRIPTION
The seek controls, showing e.g. back 10s, back 30s, etc., didn't show up when paused. This change ensures they do, which is handy when seeking around.